### PR TITLE
Glue Footer to the Bottom

### DIFF
--- a/Template/CSS/LACC.css
+++ b/Template/CSS/LACC.css
@@ -35,7 +35,7 @@ h4 {
     text-align: center;
 }
 
-.emphasis {
+em {
     font-style: italic;
 }
 

--- a/Template/CSS/LACC.css
+++ b/Template/CSS/LACC.css
@@ -1,45 +1,65 @@
-/* ----- WHOLE PAGE */
+/* ••••••• General ••••••• */
+
 body {
-    margin: 0;
-    padding: 0;
     font-size: 100%;
-}
-h1 {
-    font-size: 2.5em;
-}
-
-h2 {
-    font-size: 1.875em;
-}
-
-h3 {
-    font-size: 1.5em;
-}
-
-h4 {
-    font-size: 1.25em;
 }
 
 p {
     font: 1em arial, sans-serif;
 }
 
+h1 {
+    font-size: 2.5em;
+}
+.title {
+    text-align: center;
+}
+h2 {
+    font-size: 1.875em;
+}
+h3 {
+    font-size: 1.5em;
+}
+h4 {
+    font-size: 1.25em;
+}
+
+.indented {
+    padding-left: 3em;
+}
+
 .hanging {
     padding-left: 7.5em;
     text-indent: -4.5em;
 }
-.indented {
-    padding-left: 3em;
-}
+
 .center {
     text-align: center;
 }
-ul {
-    margin-left: 3em;
-}
+
 .emphasis {
     font-style: italic;
 }
+
+ul {
+    margin-left: 3em;
+}
+
+/* ••••••• Specific ••••••• */
+
+/* Page */
+
+body {
+    margin: 0;
+    padding: 0;
+}
+
+#sidebar {
+    width: 20%;
+    position: fixed; /* Make it stick, even on scroll */
+}
+
+/* Banner */
 
 img {
     display: block;
@@ -48,7 +68,22 @@ img {
     width: 70%;
 }
 
-/* ----- HEADER */
+#streetaddress, #email, #phone {
+    margin: 0px 1em;
+}
+
+#streetaddress {
+    text-align: center;
+}
+
+#emailphone {
+    display: flex;
+    flex-direction: row;
+    justify-content: center;
+}
+
+/* Sidebar */
+
 nav {
     margin: 0;
     list-style-type: none;
@@ -66,39 +101,33 @@ nav a {
     text-align: center;
     border-bottom: 1px solid #555;
 }
-
-nav a:last-child {
-    border-bottom: none;
-}
-
 /* Change link colour on hover */
 nav a:hover {
     background-color: #555;
     color: white;
 }
 
-#sidebar {
-    width: 20%;
-    position: fixed; /* Make it stick, even on scroll */
+nav a:last-child {
+    border-bottom: none;
 }
+
+/* Content */
 
 div.content {
     margin-left: 20%;
     padding: .5em;
 }
 
-.websitename {
+/* Footer */
+
+footer > div {
     text-align: center;
-    font-family: Helvetica, sans-serif;
-    font-size: 200%;
+    padding: 5px 10% 5px 10%;
+    background-color: rgb(202,251,255);
 }
-.mission {
-    font-family: "Comic Sans MS", cursive;
-    text-align: center;
-}
-.title {
-    text-align: center;
-}
+
+/* ••••••• Contact Us ••••••• */
+
 .map {
     margin-left: 20%;
     width: 60vw;
@@ -107,21 +136,4 @@ div.content {
     min-height: 90px;
     
     border: 1px solid lightgrey;
-}
-#streetaddress {
-    text-align: center;
-}
-#emailphone {
-    display: flex;
-    flex-direction: row;
-    justify-content: center;
-}
-#streetaddress, #email, #phone {
-    margin: 0px 1em;
-}
-/* ----- FOOTER */
-footer > div {
-    text-align: center;
-    padding: 5px 10% 5px 10%;
-    background-color: rgb(202,251,255);
 }

--- a/Template/CSS/LACC.css
+++ b/Template/CSS/LACC.css
@@ -77,7 +77,7 @@ nav a:hover {
     color: white;
 }
 
-#menu {
+#sidebar {
     width: 20%;
     position: fixed; /* Make it stick, even on scroll */
 }

--- a/Template/CSS/LACC.css
+++ b/Template/CSS/LACC.css
@@ -52,26 +52,25 @@ body {
     padding: 0;
     display: grid;
      grid-template-areas:
-        "banner"
-        "between"
-        "footer"
+        "banner banner"
+        "sidebar content"
+        "footer footer";
 }
 
 #banner {
-    grid-area: "banner"
-}
-
-#between‐banner‐and‐footer {
-    grid-area: "between"
+    grid-area: banner;
 }
 
 #sidebar {
-    width: 20%;
-    position: fixed; /* Make it stick, even on scroll */
+    grid-area: sidebar;
 }
 
-#footer {
-    grid-area: "footer"
+#content {
+    grid-area: content;
+}
+
+footer {
+    grid-area: footer;
 }
 
 /* Banner */
@@ -128,8 +127,7 @@ nav a:last-child {
 
 /* Content */
 
-div.content {
-    margin-left: 20%;
+#content {
     padding: .5em;
 }
 

--- a/Template/CSS/LACC.css
+++ b/Template/CSS/LACC.css
@@ -50,11 +50,28 @@ ul {
 body {
     margin: 0;
     padding: 0;
+    display: grid;
+     grid-template-areas:
+        "banner"
+        "between"
+        "footer"
+}
+
+#banner {
+    grid-area: "banner"
+}
+
+#between‐banner‐and‐footer {
+    grid-area: "between"
 }
 
 #sidebar {
     width: 20%;
     position: fixed; /* Make it stick, even on scroll */
+}
+
+#footer {
+    grid-area: "footer"
 }
 
 /* Banner */

--- a/Template/CSS/LACC.css
+++ b/Template/CSS/LACC.css
@@ -10,8 +10,6 @@ p {
 
 h1 {
     font-size: 2.5em;
-}
-.title {
     text-align: center;
 }
 h2 {

--- a/Template/CSS/LACC.css
+++ b/Template/CSS/LACC.css
@@ -59,7 +59,7 @@ body {
 
 /* Banner */
 
-img {
+#banner‐image {
     display: block;
     margin-left: auto;
     margin-right: auto;

--- a/Template/CSS/LACC.css
+++ b/Template/CSS/LACC.css
@@ -120,7 +120,7 @@ div.content {
     margin: 0px 1em;
 }
 /* ----- FOOTER */
-footer {
+footer > div {
     text-align: center;
     padding: 5px 10% 5px 10%;
     background-color: rgb(202,251,255);

--- a/Template/CSS/LACC.css
+++ b/Template/CSS/LACC.css
@@ -126,7 +126,7 @@ footer > div {
 
 /* ••••••• Contact Us ••••••• */
 
-.map {
+#map {
     margin-left: 20%;
     width: 60vw;
     height: calc(60vw * 9 / 16);

--- a/Template/CSS/LACC.css
+++ b/Template/CSS/LACC.css
@@ -134,7 +134,7 @@ nav a:last-child {
 
 /* Footer */
 
-footer > div {
+footer {
     text-align: center;
     padding: 5px 10% 5px 10%;
     background-color: rgb(202,251,255);

--- a/Template/CSS/LACC.css
+++ b/Template/CSS/LACC.css
@@ -50,6 +50,7 @@ ul {
 body {
     margin: 0;
     padding: 0;
+    min-height: 100vh;
     display: grid;
      grid-template-areas:
         "banner banner"

--- a/Template/CSS/LACC.css
+++ b/Template/CSS/LACC.css
@@ -56,6 +56,8 @@ body {
         "banner banner"
         "sidebar content"
         "footer footer";
+     grid-template-rows:
+        auto 1fr auto;
 }
 
 #banner {

--- a/Template/CSS/LACC.css
+++ b/Template/CSS/LACC.css
@@ -8,6 +8,10 @@ p {
     font: 1em arial, sans-serif;
 }
 
+em {
+    font-style: italic;
+}
+
 h1 {
     font-size: 2.5em;
     text-align: center;
@@ -22,6 +26,10 @@ h4 {
     font-size: 1.25em;
 }
 
+ul {
+    margin-left: 3em;
+}
+
 .indented {
     padding-left: 3em;
 }
@@ -33,14 +41,6 @@ h4 {
 
 .center {
     text-align: center;
-}
-
-em {
-    font-style: italic;
-}
-
-ul {
-    margin-left: 3em;
 }
 
 /* ••••••• Specific ••••••• */

--- a/Template/Components/Frame.html
+++ b/Template/Components/Frame.html
@@ -37,10 +37,8 @@
 
         </div>
         <footer>
-            <div>
-                <p>We have been a member church of the <a href="http://www.cccc.ca" target="_blank">Congregational Christian Churches in Canada</a> since 1989.</p>
-                <p>If my people, who are called by my name, will humble themselves and pray and seek my face and turn from their wicked ways, then I will hear from heaven, and I will forgive their sin and will heal their land.  2 Chronicles 7:14 (NIV)</p>
-            </div>
+            <p>We have been a member church of the <a href="http://www.cccc.ca" target="_blank">Congregational Christian Churches in Canada</a> since 1989.</p>
+            <p>If my people, who are called by my name, will humble themselves and pray and seek my face and turn from their wicked ways, then I will hear from heaven, and I will forgive their sin and will heal their land.  2 Chronicles 7:14 (NIV)</p>
         </footer>
     </body>
 </html>

--- a/Template/Components/Frame.html
+++ b/Template/Components/Frame.html
@@ -7,7 +7,7 @@
         <title>[*Title*]</title>
     </head>
     <body>
-        <header>
+        <header id="banner">
             <img src="[*Site Root*]Images/2007-07-24 header image.jpg" alt="Louise Avenue Congregational Church: To know Christ, and to make Him known">
             <address>
                 <p id="streetaddress">1602 Louise Avenue at 3rd Street, Saskatoon, SK, S7H 2R4</p>
@@ -17,7 +17,7 @@
                 </div>
             </address>
         </header>
-        <div id="menu">
+        <header id="sidebar">
             <nav>
                 <a href="[*Site Root*]index.html">Home</a>
                 <a href="[*Site Root*]About%20Us.html">About Us</a>
@@ -29,7 +29,7 @@
                 <a href="[*Site Root*]Our%20Missions.html">Our Missions</a>
                 <a href="[*Site Root*]Contact%20Us.html">Contact Us</a>
             </nav>
-        </div>
+        </header>
         <div class="content">
             <h1 class="title">[*Title*]</h1>
 

--- a/Template/Components/Frame.html
+++ b/Template/Components/Frame.html
@@ -17,26 +17,24 @@
                 </div>
             </address>
         </header>
-        <div id="between‐banner‐and‐footer">
-            <header id="sidebar">
-                <nav>
-                    <a href="[*Site Root*]index.html">Home</a>
-                    <a href="[*Site Root*]About%20Us.html">About Us</a>
-                    <a href="[*Site Root*]We%20Believe.html">We Believe</a>
-                    <a href="[*Site Root*]Worship%20Services.html">Worship Services</a>
-                    <a href="[*Site Root*]Sermons.html">Sermons</a>
-                    <a href="[*Site Root*]Weekly%20Activities.html">Weekly Activities</a>
-                    <a href="[*Site Root*]Events.html">Events</a>
-                    <a href="[*Site Root*]Our%20Missions.html">Our Missions</a>
-                    <a href="[*Site Root*]Contact%20Us.html">Contact Us</a>
-                </nav>
-            </header>
-            <div class="content">
-                <h1>[*Title*]</h1>
+        <header id="sidebar">
+            <nav>
+                <a href="[*Site Root*]index.html">Home</a>
+                <a href="[*Site Root*]About%20Us.html">About Us</a>
+                <a href="[*Site Root*]We%20Believe.html">We Believe</a>
+                <a href="[*Site Root*]Worship%20Services.html">Worship Services</a>
+                <a href="[*Site Root*]Sermons.html">Sermons</a>
+                <a href="[*Site Root*]Weekly%20Activities.html">Weekly Activities</a>
+                <a href="[*Site Root*]Events.html">Events</a>
+                <a href="[*Site Root*]Our%20Missions.html">Our Missions</a>
+                <a href="[*Site Root*]Contact%20Us.html">Contact Us</a>
+            </nav>
+        </header>
+        <div id="content">
+            <h1>[*Title*]</h1>
 
 [*Content*]
 
-            </div>
         </div>
         <footer>
             <div>

--- a/Template/Components/Frame.html
+++ b/Template/Components/Frame.html
@@ -8,7 +8,7 @@
     </head>
     <body>
         <header id="banner">
-            <img src="[*Site Root*]Images/2007-07-24 header image.jpg" alt="Louise Avenue Congregational Church: To know Christ, and to make Him known">
+            <img id="banner‐image" src="[*Site Root*]Images/2007-07-24 header image.jpg" alt="Louise Avenue Congregational Church: To know Christ, and to make Him known">
             <address>
                 <p id="streetaddress">1602 Louise Avenue at 3rd Street, Saskatoon, SK, S7H 2R4</p>
                 <div id="emailphone">

--- a/Template/Components/Frame.html
+++ b/Template/Components/Frame.html
@@ -17,24 +17,26 @@
                 </div>
             </address>
         </header>
-        <header id="sidebar">
-            <nav>
-                <a href="[*Site Root*]index.html">Home</a>
-                <a href="[*Site Root*]About%20Us.html">About Us</a>
-                <a href="[*Site Root*]We%20Believe.html">We Believe</a>
-                <a href="[*Site Root*]Worship%20Services.html">Worship Services</a>
-                <a href="[*Site Root*]Sermons.html">Sermons</a>
-                <a href="[*Site Root*]Weekly%20Activities.html">Weekly Activities</a>
-                <a href="[*Site Root*]Events.html">Events</a>
-                <a href="[*Site Root*]Our%20Missions.html">Our Missions</a>
-                <a href="[*Site Root*]Contact%20Us.html">Contact Us</a>
-            </nav>
-        </header>
-        <div class="content">
-            <h1 class="title">[*Title*]</h1>
+        <div id="between‐banner‐and‐footer">
+            <header id="sidebar">
+                <nav>
+                    <a href="[*Site Root*]index.html">Home</a>
+                    <a href="[*Site Root*]About%20Us.html">About Us</a>
+                    <a href="[*Site Root*]We%20Believe.html">We Believe</a>
+                    <a href="[*Site Root*]Worship%20Services.html">Worship Services</a>
+                    <a href="[*Site Root*]Sermons.html">Sermons</a>
+                    <a href="[*Site Root*]Weekly%20Activities.html">Weekly Activities</a>
+                    <a href="[*Site Root*]Events.html">Events</a>
+                    <a href="[*Site Root*]Our%20Missions.html">Our Missions</a>
+                    <a href="[*Site Root*]Contact%20Us.html">Contact Us</a>
+                </nav>
+            </header>
+            <div class="content">
+                <h1 class="title">[*Title*]</h1>
 
 [*Content*]
 
+            </div>
         </div>
         <footer>
             <div>

--- a/Template/Components/Frame.html
+++ b/Template/Components/Frame.html
@@ -36,11 +36,11 @@
 [*Content*]
 
         </div>
-        <div>
-            <footer>
+        <footer>
+            <div>
                 <p>We have been a member church of the <a href="http://www.cccc.ca" target="_blank">Congregational Christian Churches in Canada</a> since 1989.</p>
                 <p>If my people, who are called by my name, will humble themselves and pray and seek my face and turn from their wicked ways, then I will hear from heaven, and I will forgive their sin and will heal their land.  2 Chronicles 7:14 (NIV)</p>
-            </footer>
-        </div>
+            </div>
+        </footer>
     </body>
 </html>

--- a/Template/Components/Frame.html
+++ b/Template/Components/Frame.html
@@ -2,7 +2,7 @@
 <html dir="ltr" lang="en-CA">
     <head>
         <meta charset="utf-8">
-            <link rel="canonical" href="http://www.lacc.ca/[*Relative Path*]">
+        <link rel="canonical" href="http://www.lacc.ca/[*Relative Path*]">
         <link rel="stylesheet" href="[*Site Root*]CSS/LACC.css">
         <title>[*Title*]</title>
     </head>
@@ -17,29 +17,30 @@
                 </div>
             </address>
         </header>
-       <div id="menu">
-       <nav>
-            <a href="[*Site Root*]index.html">Home</a>
-            <a href="[*Site Root*]About%20Us.html">About Us</a>
-            <a href="[*Site Root*]We%20Believe.html">We Believe</a>
-            <a href="[*Site Root*]Worship%20Services.html">Worship Services</a>
-            <a href="[*Site Root*]Sermons.html">Sermons</a>
-            <a href="[*Site Root*]Weekly%20Activities.html">Weekly Activities</a>
-            <a href="[*Site Root*]Events.html">Events</a>
-            <a href="[*Site Root*]Our%20Missions.html">Our Missions</a>
-            <a href="[*Site Root*]Contact%20Us.html">Contact Us</a>
-        </nav>
-       </div>
-       <div class="content">
-        <h1 class="title">[*Title*]</h1>
+        <div id="menu">
+            <nav>
+                <a href="[*Site Root*]index.html">Home</a>
+                <a href="[*Site Root*]About%20Us.html">About Us</a>
+                <a href="[*Site Root*]We%20Believe.html">We Believe</a>
+                <a href="[*Site Root*]Worship%20Services.html">Worship Services</a>
+                <a href="[*Site Root*]Sermons.html">Sermons</a>
+                <a href="[*Site Root*]Weekly%20Activities.html">Weekly Activities</a>
+                <a href="[*Site Root*]Events.html">Events</a>
+                <a href="[*Site Root*]Our%20Missions.html">Our Missions</a>
+                <a href="[*Site Root*]Contact%20Us.html">Contact Us</a>
+            </nav>
+        </div>
+        <div class="content">
+            <h1 class="title">[*Title*]</h1>
 
 [*Content*]
-</div>
-<div>
-        <footer>
-            <p>We have been a member church of the <a href="http://www.cccc.ca" target="_blank">Congregational Christian Churches in Canada</a> since 1989.</p>
-            <p>If my people, who are called by my name, will humble themselves and pray and seek my face and turn from their wicked ways, then I will hear from heaven, and I will forgive their sin and will heal their land.  2 Chronicles 7:14 (NIV)</p>
-        </footer>
+
+        </div>
+        <div>
+            <footer>
+                <p>We have been a member church of the <a href="http://www.cccc.ca" target="_blank">Congregational Christian Churches in Canada</a> since 1989.</p>
+                <p>If my people, who are called by my name, will humble themselves and pray and seek my face and turn from their wicked ways, then I will hear from heaven, and I will forgive their sin and will heal their land.  2 Chronicles 7:14 (NIV)</p>
+            </footer>
         </div>
     </body>
 </html>

--- a/Template/Components/Frame.html
+++ b/Template/Components/Frame.html
@@ -32,7 +32,7 @@
                 </nav>
             </header>
             <div class="content">
-                <h1 class="title">[*Title*]</h1>
+                <h1>[*Title*]</h1>
 
 [*Content*]
 

--- a/Template/Pages/Contact Us.html
+++ b/Template/Pages/Contact Us.html
@@ -1,4 +1,4 @@
 <!--
  Title: Contact Us
  -->
-<iframe class="map" src="https://www.google.com/maps/embed?pb=!1m18!1m12!1m3!1d2450.336689286743!2d-106.63348668428375!3d52.110002479738654!2m3!1f0!2f0!3f0!3m2!1i1024!2i768!4f13.1!3m3!1m2!1s0x5304f1391fa8a1ad%3A0x64b31085261b3453!2sLouise+Ave+Congregational+Church!5e0!3m2!1sen!2sca!4v1519449892303" allowfullscreen></iframe>
+<iframe id="map" src="https://www.google.com/maps/embed?pb=!1m18!1m12!1m3!1d2450.336689286743!2d-106.63348668428375!3d52.110002479738654!2m3!1f0!2f0!3f0!3m2!1i1024!2i768!4f13.1!3m3!1m2!1s0x5304f1391fa8a1ad%3A0x64b31085261b3453!2sLouise+Ave+Congregational+Church!5e0!3m2!1sen!2sca!4v1519449892303" allowfullscreen></iframe>

--- a/Template/Pages/index.html
+++ b/Template/Pages/index.html
@@ -4,7 +4,7 @@
 <p>We are a neighborhood church that seeks to draw people of all ages and backgrounds together to explore the deeper questions of our Christian faith and to respond to God’s love and faithfulness in our lives and in the world.</p>
 <p>We hope that in a year we find ourselves a few more steps down the path of life … a little wiser … a little kinder … and a little closer to God.  But we know we can’t do it alone, we need God’s help, and we need each other.</p>
 <p>We take the Bible seriously.  All of our worship services on Sunday morning are centered around a text from the Bible and we seek to listen to God as he teaches us what it means to be his children, and how to live lives of love and service in his world.  As we invite people to love those around them, we also invite people to move deeper into their lives of faith with Christ.</p>
-<p><span class="emphasis">The Congregational Christian Churches in Canada are a family of churches who are passionate about God and who long to live out their lives in service to His Son Jesus Christ.</span></p>
+<p><em>The Congregational Christian Churches in Canada are a family of churches who are passionate about God and who long to live out their lives in service to His Son Jesus Christ.</em></p>
 <p>The Congregational Christian Church emphasizes The Love and Lordship of Jesus Christ</p>
 <p>You can learn more about our denomination at the link below.</p>
 


### PR DESCRIPTION
Is this what you wanted?

I did some clean‐up first (while I was trying to figure out what was where in the CSS file), so the net diff is hard to read. Only 11–15 are directly related to your question about how to do it.

If you want to see what I did, check each commit individually. (Click the little seven‐digit hash for each commit.)

1. Normalized indentation: The indentation matches the nesting structure again.
2. Swapped `footer` and `div`: `footer` has semantic meaning and is logically the outer container. (But I removed the `div` entirely later.)
3. Differentiated headers: Both the banner and the sidebar are semantically headers (anything not unique to each page is either a `header` or a `footer`.
4. Added division for everything between the banner and footer: I thought I would need a shared horizontal row, but in the end I didn’t so I undid this later.
5. Organized CSS: I grouped them so that related entries are together. (I didn’t like scanning far and wide in case a change might affect something elsewhere.)
6. Unified `title` class with `h1` element: These correlated one‐to‐one.
7. Unified `emphasis` class with `em` element: `em` (short for emphasis) has semantic weight too.
8. Further sorted CSS.
9. Limited image styling to the banner image: Every image everywhere would have been sized like the banner.
10. Limited map styling to the contact us map: Again, these apply only to that specific map.
11. Applied grid: Created a working one‐dimensional grid.
12. Assembled grid. Expanded the grid to the intended two‐dimensions.
13. Limited body shrinking: Prevented the page from being shorter than the browser window.
14. Removed extraneous `div`.
15. Specified which row to stretch. This keeps the inherent size of the first (banner) and last (footer) rows, and makes the middle row scale up to at least 1/1th of the remaining space.